### PR TITLE
[WIKI] Add ticket & PR schema to Community guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] Report"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/ticket-schema.md
+++ b/.github/ISSUE_TEMPLATE/ticket-schema.md
@@ -1,0 +1,38 @@
+---
+name: Ticket Schema
+about: A blueprint for creating consistent Issue tickets on the yumble repo.
+title: "[FEAT] Add"
+labels: ''
+assignees: ''
+
+---
+
+## Ticket starting keywords:
+WIKI
+BUG
+FEAT - 
+TEST - any tests added to the pull request
+
+## Followed by:
+* Add
+* Delete
+* Modify
+
+## Followed by:
+ Short description of what is being added, deleted or modified. 
+
+## Followed by:
+Description inside ticket
+### Acceptance guideline for description:
+* Adequately describes the details of the modification to the repo.
+* Further categorization if it helps with overall organization of the repo
+* [Optional]: Why you made this pull request
+
+E.g 
+[WIKI] Add Unit test tutorial 
+Dsc: Adding a unit test tutorial to the yumble wiki so that members of the yumble repo have a guideline to create unit tests for their own work. Improves readability, modifiability and scalability of the code.
+
+
+## Remember:
+* Link the ticket to the label of your team or the story that the ticket is a part of.
+* 1 ticket for every pull request


### PR DESCRIPTION
Adding a ticket & commit schema to make tickets and commit messages more consistent. Improves readability and review time.