### PR TITLE
[FEAT] Added new eslint rule, all caps

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -13,5 +13,6 @@ module.exports = {
   'ignorePatterns': ['**/dist/*.js', '**/node_modules/**/*.js'],
   'rules': {
     'linebreak-style': 0,
+    'new-cap': 0,
   },
 };


### PR DESCRIPTION
This new rule allows methods to start with capitals.
Certain libraries (express, mongoose) have capitals for their methods.