### PR TITLE
[FEAT] Create API for POSTing preferences

### DIFF
--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -1,6 +1,23 @@
 import express from 'express';
+import Preference from '../mongo/models/Preference';
 const router = express.Router();
 
-// TODO: Handlers...
+// POST: Creating a preferences document in the preferences collection
+router.post('/', async (req, res) => {
+  const preferences = new Preference({
+    sessionId: req.body.sessionId,
+    location: req.body.location,
+    distance: req.body.distance,
+    cuisines: req.body.cuisines,
+    price: req.body.price,
+  });
+
+  try {
+    const newPreferences = await preferences.save();
+    res.status(201).json(newPreferences);
+  } catch (error) {
+    res.status(400).json({message: error.message});
+  }
+});
 
 export default router;


### PR DESCRIPTION
- Add ability to make a POST to the **/preferences** endpoint to create a preferences object in the Preferences collection in mongoDB