### PR TITLE
Implement max price filter

### DIFF
--- a/frontend/src/components/3.Preferences/Preferences.js
+++ b/frontend/src/components/3.Preferences/Preferences.js
@@ -53,7 +53,7 @@ function Preferences() {
   async function handleSearch() {
     // console.log(Coordinates);
     const data = await getNearbyRestaurants(
-        Coordinates, Distance, 'european');
+        Coordinates, Distance, 'european', Price);
     setCardData(data);
     // console.log(data);
   }

--- a/frontend/src/components/Common/LocationHelper.js
+++ b/frontend/src/components/Common/LocationHelper.js
@@ -16,10 +16,12 @@ let cards = null;
  * @param  {Object} coordinates Object with lat and lng values
  * @param  {number} radius The radius around the defined coordinates
  * @param  {String} keyword Cuisine keyword
+ * @param  {number} priceLevel of the restaurant
  */
 export async function getNearbyRestaurants(coordinates,
     radius,
-    keyword) {
+    keyword,
+    priceLevel) {
   const pyrmont = new google.maps.LatLng(-33.8665433, 151.1956316);
   const dummyMap = new google.maps.Map(document.getElementById('dummyMap'), {
     center: pyrmont,
@@ -36,8 +38,11 @@ export async function getNearbyRestaurants(coordinates,
 
   service.nearbySearch(request, async (results, status) => {
     if (status === google.maps.places.PlacesServiceStatus.OK) {
-      cards = await getRestaurantCards(results,
-          parseLatAndLng(results));
+      cards = await getRestaurantCards(
+          results,
+          parseLatAndLng(results),
+          priceLevel,
+      );
     }
   },
   );

--- a/frontend/src/components/Common/getRestaurantCards.js
+++ b/frontend/src/components/Common/getRestaurantCards.js
@@ -9,9 +9,8 @@ let clientSecret;
 
 let dollar = "$";
 
-export async function getRestaurantCards(restaurants, coords) {
+export async function getRestaurantCards(restaurants, coords, priceLevel) {
   var cards = [];
-
   // clientCreds = await getAPIKey(1);
   // clientID = clientCreds[0];
   // clientSecret = clientCreds[1];
@@ -20,6 +19,10 @@ export async function getRestaurantCards(restaurants, coords) {
     var price;
     var suburb;
 
+    if (restaurants[i].price_level != priceLevel) {
+      continue;
+    }
+
     // const menu = await getMenu(20200305, coords[i].lat, coords[i].lng, restaurants[i].name);
 
     // get the suburb by some quick string operations
@@ -27,11 +30,7 @@ export async function getRestaurantCards(restaurants, coords) {
     suburb = suburb[suburb.length - 2];
 
     // some restaurants dont have a price level -- default to "$"
-    if (restaurants[i].price_level !== undefined) {
-      price = dollar.repeat(restaurants[i].price_level+1);
-    } else {
-      price = "$";
-    }
+    price = (restaurants[i].price_level !== undefined) ? dollar.repeat(restaurants[i].price_level) : "$";
 
     try {
       const card = {

--- a/frontend/src/components/Common/getRestaurantCards.js
+++ b/frontend/src/components/Common/getRestaurantCards.js
@@ -19,7 +19,7 @@ export async function getRestaurantCards(restaurants, coords, priceLevel) {
     var price;
     var suburb;
 
-    if (restaurants[i].price_level != priceLevel) {
+    if (restaurants[i].price_level > priceLevel) {
       continue;
     }
 


### PR DESCRIPTION
--
name: Implement max price filter
about: The users should be able to filter the restaurants by changing the settings in the preferences stage
title: "[FEAT] Modify nearby search parameters to accept max price level"
labels: Frontend
assignees: @SiyuQian 

---

* FEAT  
The price filter on the preferences page is the max value to filter all the restaurant cards. 
<img width="566" alt="Screen Shot 2021-04-05 at 1 19 55 PM" src="https://user-images.githubusercontent.com/24470452/113527483-c5ad2000-9611-11eb-8108-c3cd3e3749e3.png">
<img width="566" alt="Screen Shot 2021-04-05 at 1 20 15 PM" src="https://user-images.githubusercontent.com/24470452/113527485-c776e380-9611-11eb-8a5a-ebc513f7ac5d.png">

According to the above screenshots, the restaurant cards will be filtered by the price level preferences. For example, if we choose price level 2, then there should be no restaurant with a higher price level should be displayed.

Closes #190.
