### PR TITLE
[WIKI] .env example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Make sure to have installed the project first.
 
 Before starting the backend, you will need to create a `.env` file in the `backend` folder. Put your teams dev environment Mongo Atlas key (see [how to make a Mongo Atlas dev database](https://github.com/we-are-number-1/yumble/wiki/MongoDB-Atlas)) in the `.env` file, prefixed with `ATLAS_URI=`. 
 
+The backend folder has a `.env.example` file that can be copied, renamed, and modified for use as the `.env`.
+
 To start the backend after adding the `.env` file, run `npm start` in either the root or backend folder.
 
 #### Frontend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,11 @@
+# This file contains the variable names that are required for your .env file.
+
+# HOW TO USE:
+# First, copy and paste this file into the same directory, and rename it to ".env"
+# Then, assign the actual values to the variables, by inserting their value into the quotes.
+
+# MONGO DB Atlas URI (see https://github.com/we-are-number-1/yumble/wiki/MongoDB-Atlas)
+ATLAS_URI=""
+
+# Google Maps API Key (see https://github.com/we-are-number-1/yumble/wiki/Working-with-Google-Maps-JavaScript-API)
+GOOGLE_API_KEY=""


### PR DESCRIPTION
--
name: .env example file
about: Adding an example for the `.env` file to improve ease of setup for project
title: "[WIKI] .env example file"
labels: documentation, Backend
assignees: @seif-y 

---

Adds a file called `.env.example` that can be copied and used as the `.env` file.

Closes #260
