### PR TITLE
[FEAT] Add expiry to mongoDB documents

### DIFF
--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,0 +1,4 @@
+export default
+{
+  'session_expiry': 30,
+};

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,4 +1,5 @@
 export default
 {
-  'session_expiry': 604800,
+  // This MUST be a string value, otherwise MongoDB does not create a TTL index
+  'session_expiry': '604800s',
 };

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,4 +1,4 @@
 export default
 {
-  'session_expiry': 30,
+  'session_expiry': 604800,
 };

--- a/backend/src/mongo/models/Session.js
+++ b/backend/src/mongo/models/Session.js
@@ -3,6 +3,8 @@ import mongoose from 'mongoose';
 import {preferenceSchema} from './Preference';
 import {restaurantSchema} from './Restaurant';
 
+import config from '../../config';
+
 const sessionSchema = mongoose.Schema({
   truncCode: {
     type: String,
@@ -20,6 +22,7 @@ const sessionSchema = mongoose.Schema({
     type: [restaurantSchema],
     required: true,
   },
+  createdAt: {type: Date, expires: config, default: Date.now},
 });
 
 export default mongoose.model('Session', sessionSchema);


### PR DESCRIPTION
Add an expiry value to the `Session` MongoDB schema model, the value being one week (in seconds).
This value can be adjusted via `config.js` easily.

**We have tested this with an actual MongoDB test database, and the expiry does work.**
Notes about the expiry value has been added to the wiki: https://github.com/we-are-number-1/yumble/wiki/Yumble-Architecture-&-Design

The `createdAt` field to the document is shown here: 

![image](https://user-images.githubusercontent.com/42878423/113982969-8135b480-989d-11eb-8aff-e7f63c7ad6ab.png)

After testing with 30 second expiry, and waiting around 1 min 30 seconds, it has been deleted.
![image](https://user-images.githubusercontent.com/42878423/113983153-b80bca80-989d-11eb-93f3-30e2ba71979e.png)

I have also tested a full run-through to ensure that the expiry setting does not muck up the other storage of the Sessions.

If you would like to test that the expiry works, you can use the testDatabase instance I have set up in our Cluster. I've just been running the game until we get to the part where we choose our restaurant choices...and just wait until the document has been deleted from testDatabase (indexing it does not refresh the ttl, we are expiring based on `createdAt`).

Note that MongoDB only runs checks for expired documents every 60 seconds, so there is some sort of delay with deletion.

Closes #278

Co-authored-by: @skyn310198 