### PR TITLE
[BUG] Removed memory leak to do with games/sessions not being removed from map

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon src --exec babel-node",
     "build": "babel src -d dist",
     "start": "npm run build && node dist/index.js",
+    "inspect": "npm run build && node --inspect dist/index.js",
     "lint": "eslint .",
     "fix-lint": "eslint . --fix"
   },

--- a/backend/src/domain/models/Game.js
+++ b/backend/src/domain/models/Game.js
@@ -89,6 +89,6 @@ export class Game {
     this.io.to(this.session.sessionId).emit('end_game');
     // Remove game from active games list
     Games.removeGame(this.session.sessionId);
-    console.log("removed game:", this.session.sessionId);
+    console.log('removed game:', this.session.sessionId);
   }
 }

--- a/backend/src/domain/models/Game.js
+++ b/backend/src/domain/models/Game.js
@@ -17,7 +17,7 @@ export class Game {
     this.roundInterval = session.preferences.roundInterval;
     this.round = 0;
     this.countdown = 4;
-    this.gameActive = true;
+    this.gameActive = false;
   }
 
   /**
@@ -26,6 +26,7 @@ export class Game {
    * 0 represents the start of the game (calling nextRound)
    */
   async startCountdown() {
+    this.gameActive = true;
     // Let all users in game start countdown
     this.io.to(this.session.sessionId).emit(
         'countdown', {

--- a/backend/src/domain/models/Game.js
+++ b/backend/src/domain/models/Game.js
@@ -1,3 +1,4 @@
+import Games from '../Games';
 
 /**
  * Main game controller for the application.
@@ -85,5 +86,7 @@ export class Game {
     this.session.syncDb();
     await this.sleep(200);
     this.io.to(this.session.sessionId).emit('end_game');
+    // Remove game from active games list
+    Games.removeGame(this.session.sessionId);
   }
 }

--- a/backend/src/domain/models/Game.js
+++ b/backend/src/domain/models/Game.js
@@ -89,5 +89,6 @@ export class Game {
     this.io.to(this.session.sessionId).emit('end_game');
     // Remove game from active games list
     Games.removeGame(this.session.sessionId);
+    console.log("removed game:", this.session.sessionId);
   }
 }

--- a/backend/src/domain/models/SocketSession.js
+++ b/backend/src/domain/models/SocketSession.js
@@ -48,13 +48,13 @@ export class SocketSession {
     } else {
       this.votes.set(
           restaurant.name,
-          {votes: 1, 
-          location: restaurant.location,
-          coords: restaurant.coords,
-          cuisine: restaurant.cuisine,
-          price: restaurant.price,
-          rating: restaurant.rating,
-          images: restaurant.images},
+          {votes: 1,
+            location: restaurant.location,
+            coords: restaurant.coords,
+            cuisine: restaurant.cuisine,
+            price: restaurant.price,
+            rating: restaurant.rating,
+            images: restaurant.images},
       );
     }
   }
@@ -68,14 +68,14 @@ export class SocketSession {
       const restaurants = [];
       this.votes.forEach((value, key, map) => {
         restaurants.push(
-            {name: key, 
-            location: value.location, 
-            numberOfVotes: value.votes,
-            coords: value.coords,
-            cuisine: value.cuisine,
-            price: value.price,
-            rating: value.rating,
-            images: value.images},
+            {name: key,
+              location: value.location,
+              numberOfVotes: value.votes,
+              coords: value.coords,
+              cuisine: value.cuisine,
+              price: value.price,
+              rating: value.rating,
+              images: value.images},
         );
       });
       console.log(restaurants);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -69,6 +69,7 @@ io.on('connection', (socket) => {
   SocketEvents.leaveRoom(socket, io, () => {});
   SocketEvents.setRestaurants(socket);
   SocketEvents.vote(socket);
+  SocketEvents.hostRoom(socket, io);
 });
 
 server.listen(PORT, () => {

--- a/backend/src/mongo/models/Restaurant.js
+++ b/backend/src/mongo/models/Restaurant.js
@@ -19,7 +19,7 @@ const restaurantSchema = mongoose.Schema({
     default: {
       lat: 0.0,
       lng: 0.0,
-    }
+    },
   },
   cuisine: {
     type: String,

--- a/backend/src/routes/__tests__/sessions.test.js
+++ b/backend/src/routes/__tests__/sessions.test.js
@@ -101,7 +101,7 @@ describe('PATCH', () => {
           cuisine: 'Thai',
           price: '$$',
           rating: 3.5,
-          images: ''
+          images: '',
         },
         {
           name: 'Japanese Restaurant',
@@ -114,7 +114,7 @@ describe('PATCH', () => {
           cuisine: 'Japanese',
           price: '$$',
           rating: 3.5,
-          images: ''
+          images: '',
         },
         {
           name: 'Chinese Restaurant',
@@ -127,7 +127,7 @@ describe('PATCH', () => {
           cuisine: 'Chinese',
           price: '$$$$',
           rating: 4.3,
-          images: ''
+          images: '',
         },
       ],
     };

--- a/backend/src/sockets/disconnect.js
+++ b/backend/src/sockets/disconnect.js
@@ -1,4 +1,4 @@
-import games from '../domain/Games';
+import games from "../domain/Games";
 /**
  * Socket event for when a user disconnects.
  * @param {*} socket
@@ -6,24 +6,33 @@ import games from '../domain/Games';
  * @param {*} cb callback function
  */
 export function disconnect(socket, io, cb) {
-  socket.on('disconnect', () => {
+  socket.on("disconnect", () => {
     const activeGames = games.getGames();
 
     activeGames.forEach((game) => {
+      const users = Array.from(game.session.users.values()).map(
+        (e) => e.name
+      );
+      // Indicate host has left
+      if (game.session.hostSocket && socket.id === game.session.hostSocket.id) {
+        game.session.hostSocket = null;
+      }
+      // Remove users with same socket
       if (game.session.removeUser(socket)) {
-        const users = Array.from(
-            game.session.users.values()).map((e) => e.name);
+        // Recalculate users as have been changed
+        users = Array.from(game.session.users.values()).map((e) => e.name);
         console.log(users);
-        // Remove the game if the game hasnt started and no one is in the lobby
-        // To prevent a memory leak
-        if(users.length==0 && game.gameActive==false){
-          games.removeGame(game.session.sessionId);
-        }else{
-          io.to(game.session.sessionId).emit('new_user', {users: users});
-        }
+        io.to(game.session.sessionId).emit("new_user", { users: users });
+      }
+      // Remove the game if the game hasnt started and no one is in the lobby
+      // To prevent a memory leak
+      console.log(users);
+      if (!game.session.hostSocket && users.length == 0 && !game.gameActive) {
+        games.removeGame(game.session.sessionId);
+        console.log("removed game:", game.session.sessionId);
       }
     });
-    console.log('user disconnected with id:', socket.id);
+    console.log("user disconnected with id:", socket.id);
     cb();
   });
 }

--- a/backend/src/sockets/disconnect.js
+++ b/backend/src/sockets/disconnect.js
@@ -21,7 +21,6 @@ export function disconnect(socket, io, cb) {
       if (game.session.removeUser(socket)) {
         // Recalculate users as have been changed
         users = Array.from(game.session.users.values()).map((e) => e.name);
-        console.log(users);
         io.to(game.session.sessionId).emit('new_user', {users: users});
       }
       // Remove the game if the game hasnt started and no one is in the lobby

--- a/backend/src/sockets/disconnect.js
+++ b/backend/src/sockets/disconnect.js
@@ -1,4 +1,4 @@
-import games from "../domain/Games";
+import games from '../domain/Games';
 /**
  * Socket event for when a user disconnects.
  * @param {*} socket
@@ -6,12 +6,12 @@ import games from "../domain/Games";
  * @param {*} cb callback function
  */
 export function disconnect(socket, io, cb) {
-  socket.on("disconnect", () => {
+  socket.on('disconnect', () => {
     const activeGames = games.getGames();
 
     activeGames.forEach((game) => {
       const users = Array.from(game.session.users.values()).map(
-        (e) => e.name
+          (e) => e.name,
       );
       // Indicate host has left
       if (game.session.hostSocket && socket.id === game.session.hostSocket.id) {
@@ -22,17 +22,17 @@ export function disconnect(socket, io, cb) {
         // Recalculate users as have been changed
         users = Array.from(game.session.users.values()).map((e) => e.name);
         console.log(users);
-        io.to(game.session.sessionId).emit("new_user", { users: users });
+        io.to(game.session.sessionId).emit('new_user', {users: users});
       }
       // Remove the game if the game hasnt started and no one is in the lobby
       // To prevent a memory leak
       console.log(users);
       if (!game.session.hostSocket && users.length == 0 && !game.gameActive) {
         games.removeGame(game.session.sessionId);
-        console.log("removed game:", game.session.sessionId);
+        console.log('removed game:', game.session.sessionId);
       }
     });
-    console.log("user disconnected with id:", socket.id);
+    console.log('user disconnected with id:', socket.id);
     cb();
   });
 }

--- a/backend/src/sockets/disconnect.js
+++ b/backend/src/sockets/disconnect.js
@@ -14,7 +14,13 @@ export function disconnect(socket, io, cb) {
         const users = Array.from(
             game.session.users.values()).map((e) => e.name);
         console.log(users);
-        io.to(game.session.sessionId).emit('new_user', {users: users});
+        // Remove the game if the game hasnt started and no one is in the lobby
+        // To prevent a memory leak
+        if(users.length==0 && game.gameActive==false){
+          games.removeGame(game.session.sessionId);
+        }else{
+          io.to(game.session.sessionId).emit('new_user', {users: users});
+        }
       }
     });
     console.log('user disconnected with id:', socket.id);

--- a/backend/src/sockets/hostRoom.js
+++ b/backend/src/sockets/hostRoom.js
@@ -1,6 +1,7 @@
 import games from '../domain/Games';
 /**
- * Handles event when hosts a room. should set the host socket property in the room
+ * Handles event when hosts a room. should set the host socket property in
+ * the room
  * @param {*} socket
  * @param {*} io
  */

--- a/backend/src/sockets/hostRoom.js
+++ b/backend/src/sockets/hostRoom.js
@@ -1,0 +1,20 @@
+import games from '../domain/Games';
+/**
+ * Handles event when hosts a room. should set the host socket property in the room
+ * @param {*} socket
+ * @param {*} io
+ */
+export function hostRoom(socket, io) {
+  socket.on('host_room', ({sessionId}) => {
+    const game = games.getGame(sessionId);
+    if (!game || game.session.users.size >= 10) {
+      io.to(socket.id).emit('invalid_code', true);
+      console.log('Invalid game code: ' + sessionId);
+      return;
+    }
+    io.to(socket.id).emit('invalid_code', false);
+
+    game.session.hostSocket = socket;
+    socket.join(sessionId);
+  });
+}

--- a/backend/src/sockets/index.js
+++ b/backend/src/sockets/index.js
@@ -4,3 +4,5 @@ export {start} from './start';
 export {leaveRoom} from './leaveRoom';
 export {vote} from './vote';
 export {setRestaurants} from './setRestaurants';
+export {hostRoom} from './hostRoom';
+

--- a/backend/src/sockets/joinRoom.js
+++ b/backend/src/sockets/joinRoom.js
@@ -14,9 +14,6 @@ export function joinRoom(socket, io) {
     }
     io.to(socket.id).emit('invalid_code', false);
 
-    if (!game.session.hostSocket) {
-      game.session.hostSocket = socket;
-    }
     game.session.addUser(socket, name);
     socket.join(sessionId);
     const users = Array.from(game.session.users.values()).map((e) => e.name);

--- a/backend/src/sockets/leaveRoom.js
+++ b/backend/src/sockets/leaveRoom.js
@@ -13,7 +13,13 @@ export function leaveRoom(socket, io, cb = null) {
         const users = Array.from(
             game.session.users.values()).map((e) => e.name);
         console.log(users);
-        io.to(game.session.sessionId).emit('new_user', {users: users});
+        // Remove the game if the game hasnt started and no one is in the lobby
+        // To prevent a memory leak
+        if(users.length==0 && game.gameActive==false){
+          games.removeGame(game.session.sessionId);
+        }else{
+          io.to(game.session.sessionId).emit('new_user', {users: users});
+        }
       }
     });
     console.log('user left room with id:', socket.id);

--- a/backend/src/sockets/leaveRoom.js
+++ b/backend/src/sockets/leaveRoom.js
@@ -1,4 +1,4 @@
-import games from "../domain/Games";
+import games from '../domain/Games';
 /**
  * Socket event for when a user disconnects.
  * @param {*} socket
@@ -6,7 +6,7 @@ import games from "../domain/Games";
  * @param {*} cb callback function
  */
 export function leaveRoom(socket, io, cb = null) {
-  socket.on("leave_room", () => {
+  socket.on('leave_room', () => {
     const activeGames = games.getGames();
 
     activeGames.forEach((game) => {
@@ -20,18 +20,18 @@ export function leaveRoom(socket, io, cb = null) {
         // Recalculate users as have been changed
         users = Array.from(game.session.users.values()).map((e) => e.name);
         console.log(users);
-        io.to(game.session.sessionId).emit("new_user", { users: users });
+        io.to(game.session.sessionId).emit('new_user', {users: users});
       }
       // Remove the game if the game hasnt started and no one is in the lobby
       // To prevent a memory leak
       if (!game.session.hostSocket && users.length == 0 && !game.gameActive) {
         games.removeGame(game.session.sessionId);
-        console.log("removed game:", game.session.sessionId);
+        console.log('removed game:', game.session.sessionId);
       }
     });
-    console.log("user left room with id:", socket.id);
+    console.log('user left room with id:', socket.id);
     if (cb) {
-      console.log("done is called");
+      console.log('done is called');
       cb(socket.id);
     }
   });

--- a/backend/src/sockets/leaveRoom.js
+++ b/backend/src/sockets/leaveRoom.js
@@ -1,4 +1,4 @@
-import games from '../domain/Games';
+import games from "../domain/Games";
 /**
  * Socket event for when a user disconnects.
  * @param {*} socket
@@ -6,25 +6,32 @@ import games from '../domain/Games';
  * @param {*} cb callback function
  */
 export function leaveRoom(socket, io, cb = null) {
-  socket.on('leave_room', () => {
+  socket.on("leave_room", () => {
     const activeGames = games.getGames();
+
     activeGames.forEach((game) => {
+      let users = Array.from(game.session.users.values()).map((e) => e.name);
+      // Indicate host has left
+      if (game.session.hostSocket && socket.id === game.session.hostSocket.id) {
+        game.session.hostSocket = null;
+      }
+      // Remove users with same socket
       if (game.session.removeUser(socket)) {
-        const users = Array.from(
-            game.session.users.values()).map((e) => e.name);
+        // Recalculate users as have been changed
+        users = Array.from(game.session.users.values()).map((e) => e.name);
         console.log(users);
-        // Remove the game if the game hasnt started and no one is in the lobby
-        // To prevent a memory leak
-        if(users.length==0 && game.gameActive==false){
-          games.removeGame(game.session.sessionId);
-        }else{
-          io.to(game.session.sessionId).emit('new_user', {users: users});
-        }
+        io.to(game.session.sessionId).emit("new_user", { users: users });
+      }
+      // Remove the game if the game hasnt started and no one is in the lobby
+      // To prevent a memory leak
+      if (!game.session.hostSocket && users.length == 0 && !game.gameActive) {
+        games.removeGame(game.session.sessionId);
+        console.log("removed game:", game.session.sessionId);
       }
     });
-    console.log('user left room with id:', socket.id);
+    console.log("user left room with id:", socket.id);
     if (cb) {
-      console.log('done is called');
+      console.log("done is called");
       cb(socket.id);
     }
   });

--- a/backend/src/sockets/leaveRoom.js
+++ b/backend/src/sockets/leaveRoom.js
@@ -19,7 +19,6 @@ export function leaveRoom(socket, io, cb = null) {
       if (game.session.removeUser(socket)) {
         // Recalculate users as have been changed
         users = Array.from(game.session.users.values()).map((e) => e.name);
-        console.log(users);
         io.to(game.session.sessionId).emit('new_user', {users: users});
       }
       // Remove the game if the game hasnt started and no one is in the lobby

--- a/frontend/src/components/3.Preferences/Preferences.js
+++ b/frontend/src/components/3.Preferences/Preferences.js
@@ -64,6 +64,9 @@ function Preferences() {
     }
   }, [cardData]);
 
+  const goBack = () => {
+    SocketEvents.leaveRoom(socketContext.socket);
+  };
 
   const postPreference = () => {
     socketContext.setCode(code);
@@ -164,8 +167,9 @@ function Preferences() {
             </div>
           </div>
           <Link to='/'>
-            <Button variant='danger' size='lg' id='BackButton'>
-              Back
+            <Button variant='danger' size='lg' id='BackButton'
+              onClick={() => goBack()}>
+                Back
             </Button>
           </Link>
 

--- a/frontend/src/components/3.Preferences/Preferences.js
+++ b/frontend/src/components/3.Preferences/Preferences.js
@@ -44,6 +44,8 @@ function Preferences() {
     axios.post('sessions', response).then((response) => {
       // ensure you only do it once
       setCode(response.data.truncCode);
+      // Host room once session has been created
+      SocketEvents.hostRoom(socketContext.socket, response.data.truncCode);
     });
   }, []);
 

--- a/frontend/src/sockets/hostRoom.js
+++ b/frontend/src/sockets/hostRoom.js
@@ -1,0 +1,8 @@
+/**
+ * Emits a host_room even to backend sockets
+ * @param {*} socket
+ * @param {*} sessionId
+ */
+export function hostRoom(socket, sessionId) {
+  socket.emit('host_room', {sessionId});
+}

--- a/frontend/src/sockets/index.js
+++ b/frontend/src/sockets/index.js
@@ -9,3 +9,4 @@ export {updateRestaurants} from './updateRestaurants';
 export {invalidCode} from './invalidCode';
 export {leaveRoom} from './leaveRoom';
 export {vote} from './vote';
+export {hostRoom} from './hostRoom';


### PR DESCRIPTION
Closes #275 
Removes the game from the activeGames map when the game is finished.
Required the creation of an extra socket event as during the preferences stage, there was no reference to which game belonged to which socket, thus making it impossible to reference to delete.
The new socket event `"host_room"` sets the selected room code host to be the socket  caller.

## Before:
![Screenshot 2021-04-08 172945 (2)](https://user-images.githubusercontent.com/49135923/113974431-06b36780-9892-11eb-93a2-ff9298e9a383.png)
## After:
![Screenshot 2021-04-08 174316](https://user-images.githubusercontent.com/49135923/113974470-19c63780-9892-11eb-8b3c-090096bcf1a3.png)
As seen in the heap comparison snapshots above, the change removes the residual `Game`s and `SocketSession`s in memory. 

From my testing, there seem to be no other memory leaks from the server.

## Note
I have also added a new npm script to run the server in inspect mode.

Use `npm run inspect` to run the script.

Assuming that chrome or a chromium based browser is being used, DevTools can be accessed through `chrome://inspect`, which can be useful for accessing memory information from a server being run locally.
