### PR TITLE
[BUG] mongoDB Session schema expiry index not working

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,4 +11,5 @@ ATLAS_URI=""
 GOOGLE_API_KEY=""
 
 # MONGO DB Session Schema Expiry Index. The value is integer (https://github.com/we-are-number-1/yumble/wiki/Yumble-Architecture-&-Design#database---mongodb)
+# You should set this integer to be 604800 (one week), unless you are testing - with a separate database of course.
 SESSION_EXPIRY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,6 @@ ATLAS_URI=""
 
 # Google Maps API Key (see https://github.com/we-are-number-1/yumble/wiki/Working-with-Google-Maps-JavaScript-API)
 GOOGLE_API_KEY=""
+
+# MONGO DB Session Schema Expiry Index. The value is integer (https://github.com/we-are-number-1/yumble/wiki/Yumble-Architecture-&-Design#database---mongodb)
+SESSION_EXPIRY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,7 @@
 # This file contains the variable names that are required for your .env file.
 
+# PLEASE READ https://github.com/we-are-number-1/yumble/wiki/Yumble-Architecture-&-Design#database---mongodb
+
 # HOW TO USE:
 # First, copy and paste this file into the same directory, and rename it to ".env"
 # Then, assign the actual values to the variables, by inserting their value into the quotes.
@@ -10,6 +12,6 @@ ATLAS_URI=""
 # Google Maps API Key (see https://github.com/we-are-number-1/yumble/wiki/Working-with-Google-Maps-JavaScript-API)
 GOOGLE_API_KEY=""
 
-# MONGO DB Session Schema Expiry Index. The value is integer (https://github.com/we-are-number-1/yumble/wiki/Yumble-Architecture-&-Design#database---mongodb)
+# MONGO DB Session Schema Expiry Index. The value is integer.
 # You should set this integer to be 604800 (one week), unless you are testing - with a separate database of course.
 SESSION_EXPIRY=

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,5 +1,0 @@
-export default
-{
-  // This MUST be a string value, otherwise MongoDB does not create a TTL index
-  'session_expiry': '604800s',
-};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,15 +2,14 @@ import express from 'express';
 import http from 'http';
 import path from 'path';
 import socketio from 'socket.io';
-import mongoose from 'mongoose';
 import games from './domain/Games';
 import {SocketSession} from './domain/models/SocketSession';
 import * as SocketEvents from './sockets';
+import * as mongo from './mongo/index';
 
 // Routes
 import sessionsRouteAPI from './routes/sessions';
 import keysRouteAPI from './routes/keys';
-
 
 const app = express();
 const server = http.createServer(app);
@@ -24,18 +23,9 @@ app.use(express.json());
 app.use('/sessions', sessionsRouteAPI);
 app.use('/api/keys', keysRouteAPI);
 
-const mongoUri = process.env.ATLAS_URI;
-mongoose.connect(
-    mongoUri,
-    {useNewUrlParser: true, useUnifiedTopology: true},
-    (err) => {
-      if (err) {
-        throw err;
-      } else {
-        console.log(`Successfully connected to MongoDB Atlas.`);
-      }
-    },
-);
+// MongoDB Setup
+mongo.connect();
+mongo.configureSessionIndexes();
 
 const PORT = process.env.PORT || 3001;
 

--- a/backend/src/mongo/__tests__/index.test.js
+++ b/backend/src/mongo/__tests__/index.test.js
@@ -1,0 +1,92 @@
+import MongoMemoryServer from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import express from 'express';
+
+import Session from '../models/Session';
+import * as mongo from '../../mongo/index';
+
+let mongoServer;
+let server;
+let collection;
+
+describe('MongoDB startup functions', () => {
+  const OLD_ENV = process.env;
+
+  beforeAll(async (done) => {
+    mongoServer = new MongoMemoryServer();
+
+    const connectionString = await mongoServer.getUri();
+    await mongoose.connect(connectionString, {
+      useNewUrlParser: true,
+      useCreateIndex: true,
+      useUnifiedTopology: true,
+      useFindAndModify: false,
+    });
+
+    const app = express();
+    app.use(express.json());
+
+    server = app.listen(0, () => {
+      done();
+    });
+  });
+
+  beforeEach(async () => {
+    collection = await mongoose.connection.db.createCollection('sessions');
+
+    jest.resetModules();
+    process.env = {...OLD_ENV};
+    process.env.SESSION_EXPIRY = '604800';
+  });
+
+  afterEach(async () => {
+    await mongoose.connection.db.dropCollection('sessions');
+  });
+
+  afterAll((done) => {
+    server.close(async () => {
+      await mongoose.disconnect();
+      await mongoServer.stop();
+
+      process.env = OLD_ENV;
+      done();
+    });
+  });
+
+  test('Create createdAt index', async (done) => {
+    await mongo.configureSessionIndexes();
+    const indexIsCreated = await mongo.collectionHasIndex(Session, 'createdAt');
+
+    expect(indexIsCreated).toBe(true);
+    done();
+  });
+
+  test('Create createdAt index when it exists already', async (done) => {
+    Session.collection.createIndex({'createdAt': 1},
+        {expireAfterSeconds: process.env.SESSION_EXPIRY});
+    await mongo.configureSessionIndexes();
+    const indexIsCreated = await mongo.collectionHasIndex(Session, 'createdAt');
+
+    expect(indexIsCreated).toBe(true);
+    done();
+  });
+
+  test('Session expires correctly', async (done) => {
+    process.env.SESSION_EXPIRY = 0;
+    await mongo.configureSessionIndexes();
+
+    const mockSession = new Session({
+      _id: '123',
+      preferences: {},
+      results: [], createdAt: Date.now,
+    });
+    await collection.insertOne(mockSession)
+        .catch((err) => done.fail(new Error(err.message)));
+
+    const foundSession = await collection.findOne({_id: '123'})
+        .catch((err) => done.fail(new Error(err.message)));
+
+    expect(foundSession).toBeNull();
+    done();
+  });
+});

--- a/backend/src/mongo/index.js
+++ b/backend/src/mongo/index.js
@@ -13,7 +13,7 @@ function connect() {
         if (err) {
           throw err;
         } else {
-          console.log(`Successfully connected to MongoDB Atlas.`);
+          console.log('Successfully connected to MongoDB Atlas.');
         }
       },
   );
@@ -47,12 +47,12 @@ async function configureSessionIndexes() {
  * @return {boolean}
  */
 async function collectionHasIndex(schema, indexName) {
-  const indices = await schema.collection.getIndexes();
+  const indexes = await schema.collection.getIndexes();
   let hasIndex = false;
 
   // getIndexes() returns an object, which contains keys of each index,
-  // the value being a double nested array
-  Object.values(indices).forEach((index) => {
+  // the values being [ [indexName, mode] ]
+  Object.values(indexes).forEach((index) => {
     if (index[0][0] === indexName) {
       hasIndex = true;
     }
@@ -61,4 +61,4 @@ async function collectionHasIndex(schema, indexName) {
   return hasIndex;
 }
 
-export {connect, configureSessionIndexes};
+export {connect, configureSessionIndexes, collectionHasIndex};

--- a/backend/src/mongo/index.js
+++ b/backend/src/mongo/index.js
@@ -1,0 +1,64 @@
+import mongoose from 'mongoose';
+import Session from './models/Session';
+
+/**
+ * Connect to the MongoDB database, using the ATLAS_URI from .env
+ */
+function connect() {
+  const mongoUri = process.env.ATLAS_URI;
+  mongoose.connect(
+      mongoUri,
+      {useNewUrlParser: true, useUnifiedTopology: true},
+      (err) => {
+        if (err) {
+          throw err;
+        } else {
+          console.log(`Successfully connected to MongoDB Atlas.`);
+        }
+      },
+  );
+}
+
+/**
+ * Refresh the database indexes for {Session}. If you want to set a different
+ * expiry for the {Session} MongoDB schema, you MUST drop the index and recreate
+ *
+ * This function is therefore called everytime you restart the app to avoid
+ * expiry issues (see issue #296)
+ */
+async function configureSessionIndexes() {
+  const sessionExpiry = parseInt(process.env.SESSION_EXPIRY);
+  const ascendingIndexMode = 1;
+  const mongoDefinitionSuffix = '_1'; // Mongo appends suffix to definition
+
+  if (await collectionHasIndex(Session, 'createdAt')) {
+    await Session.collection.dropIndex('createdAt' + mongoDefinitionSuffix);
+  }
+  await Session.collection.createIndex({'createdAt': ascendingIndexMode},
+      {expireAfterSeconds: sessionExpiry});
+
+  console.log('Successfully configured MongoDB Atlas collection');
+}
+
+/**
+ * Helper function to check if index for a schema exists in the db collection
+ * @param {*} schema, MongoDB model
+ * @param {*} indexName, string, the name of the index to search for
+ * @return {boolean}
+ */
+async function collectionHasIndex(schema, indexName) {
+  const indices = await schema.collection.getIndexes();
+  let hasIndex = false;
+
+  // getIndexes() returns an object, which contains keys of each index,
+  // the value being a double nested array
+  Object.values(indices).forEach((index) => {
+    if (index[0][0] === indexName) {
+      hasIndex = true;
+    }
+  });
+
+  return hasIndex;
+}
+
+export {connect, configureSessionIndexes};

--- a/backend/src/mongo/models/Session.js
+++ b/backend/src/mongo/models/Session.js
@@ -2,8 +2,6 @@ import mongoose from 'mongoose';
 
 import {preferenceSchema} from './Preference';
 import {restaurantSchema} from './Restaurant';
-// TODO: Jenifer could you look at this change?
-//import config from '../../config';
 
 const sessionSchema = mongoose.Schema({
   truncCode: {
@@ -22,8 +20,7 @@ const sessionSchema = mongoose.Schema({
     type: [restaurantSchema],
     required: true,
   },
-  // TODO: Jenifer could you look at this change?
-  //createdAt: {type: Date, expires: config.session_expiry, default: Date.now},
+  createdAt: {type: Date, default: Date.now},
 });
 
 export default mongoose.model('Session', sessionSchema);

--- a/backend/src/mongo/models/__mocks__/Session.js
+++ b/backend/src/mongo/models/__mocks__/Session.js
@@ -4,7 +4,7 @@
  */
 class MockSession {
   /**
-    *
+    * Mock findOne of the {Session} mongo schema
     * @param {*} code
     * @return {*}
     */


### PR DESCRIPTION
### The problem
**Mongodb does not allow you to modify indexes, especially the TTL value.** We had assumed that you could, so everyime we saved a `Session` document with a certain expiry value, we assumed that value would override the old one. It did not.

We had first tested the creation of an index with 30 seconds. Therefore, the index TTL value was always being referenced to as 30 seconds - documents were expiring at least 30 seconds and caused `SocketSession` null pointer exceptions as a result.

### Solution
* Drop and recreate the index everytime you restart the app. This will allow the user to define the `expireAtSeconds` value to whatever they want, which makes things easier. HOWEVER, **please do not test with `myFirstDatabase`, as everytime you drop and create an index for MongoDB, it blocks all over operations on the database**. So you can use `testDatabase` if you want
* Extracted expiry time to `.env`. Added the example to `.env.example`. No longer need config file (no idea why I did this in the first place tbh)
* Created tests for index creation, dropping and `Session` expiry
* Refactored mongo methods out of `index.js`

As a result, `myFirstDatabase` expiry for `Session`'s `createdAt` index is 1 week. It has already been updated anyway.
![image](https://user-images.githubusercontent.com/42878423/114317245-406ac380-9b5b-11eb-901d-31059dd52ddd.png)

I have tested _both_ when you first create an index, and when you try to refresh the index value when it already exists.

Also, I wrote some notes here: https://github.com/we-are-number-1/yumble/wiki/Yumble-Architecture-&-Design#database---mongodb and https://github.com/we-are-number-1/yumble/wiki/MongoDB-Atlas

Closes #296 
