### PR TITLE
[FIX] Fix Dropdown border weirdness

### DIFF
--- a/frontend/src/components/3.Preferences/AutocompleteSearchBox.css
+++ b/frontend/src/components/3.Preferences/AutocompleteSearchBox.css
@@ -26,16 +26,16 @@ textarea {
 .Suggestions {
   border: 3px solid #000000;
   border-radius: 0.5rem;
+  background-color: #202020;
   position: absolute;
   z-index: 5;
   width: 100%;
-  right: 0px;
   left: -0.5vw;
+  overflow: hidden;
 }
 
 .SuggestionItem {
   padding: 0.5em 0 0.5em 0;
-  background-color: #202020;
   color: #a9a9a9;
   padding-left: 0.4em;
 }


### PR DESCRIPTION
Minor CSS modification to the auto search bar dropdown in the Preferences page. There should be no gaps visible anymore between the border and the items, and the hover color shouldn't go over the border corners either anymore.


Before:
![image](https://user-images.githubusercontent.com/7234148/115250220-791f2400-a17d-11eb-893a-a994dc4ada51.png)

After:
![image](https://user-images.githubusercontent.com/7234148/115250321-8d632100-a17d-11eb-9010-d7a3ae1263d8.png)

