### PR TITLE
[FEAT] Show all results in pie chart

### DIFF
--- a/frontend/src/components/7.Result/ResultPage.js
+++ b/frontend/src/components/7.Result/ResultPage.js
@@ -66,7 +66,7 @@ function ResultPage(props) {
       ',' +
       (60 + 30 * Math.random()) +
       '%,' +
-      80 +
+      60 +
       '%)'
     );
   };

--- a/frontend/src/components/7.Result/ResultPage.js
+++ b/frontend/src/components/7.Result/ResultPage.js
@@ -60,15 +60,7 @@ function ResultPage(props) {
    * @return {string} A string that represents a HSL colour value
    */
   const randomColour = () => {
-    return (
-      'hsl(' +
-      360 * Math.random() +
-      ',' +
-      (60 + 30 * Math.random()) +
-      '%,' +
-      60 +
-      '%)'
-    );
+    return 'hsl(' + 360 * Math.random() + ',' + 100 + '%,' + 60 + '%)';
   };
 
   useEffect(() => {

--- a/frontend/src/components/7.Result/ResultPage.js
+++ b/frontend/src/components/7.Result/ResultPage.js
@@ -27,7 +27,6 @@ const rating = 4.0;
 /**
  * @param {*} props
  * @return {*}
- * TODO: remove hard-coded location for the winning restaurant coordinates
  *
  * This is the result screen. The users in the game be shown the most voted restaurant
  * that has won the game. Users can choose to see the vote breakdown, that is shown on a popup
@@ -54,12 +53,26 @@ function ResultPage(props) {
   // need to have props due to the testing purpose
   const [hasResult, setHasResult] = useState(props.hasResult);
 
+  const pieColours = [];
+
+  /**
+   * This function generates a random RGB value
+   * @return {string} A string that represents an RGB colour value
+   */
+  const randomColour = () => {
+    const r = Math.floor(Math.random() * 255);
+    const g = Math.floor(Math.random() * 255);
+    const b = Math.floor(Math.random() * 255);
+    return 'rgb(' + r + ',' + g + ',' + b + ')';
+  };
+
   useEffect(() => {
     document.title = 'Time to go eat!';
     axios
       .get('sessions/' + socketContext.code)
       .then((res) => {
         setHasResult(false);
+        // Sort Restaurants by number of Keen votes
         setCardList(
           res.data.results.sort(function (a, b) {
             return b.numberOfVotes - a.numberOfVotes;
@@ -71,13 +84,19 @@ function ResultPage(props) {
       });
   }, []);
 
-  // Creating the pie chart from the vote data.
+  // Creating the Top Choice Card and pie chart from the vote data.
   // Each selected restaurant is shown as a legend and the overall voting
   // distribution is shown.
   useEffect(() => {
     if (cardList && cardList.length > 0) {
       setHasResult(true);
-      const card = cardList[0];
+      // Get all restaurants that have the most keens
+      const topRestaurants = cardList.filter(
+        (card) => card.numberOfVotes === cardList[0].numberOfVotes
+      );
+      // Select a top restaurant randomly
+      const card =
+        topRestaurants[Math.floor(Math.random() * topRestaurants.length)];
       setData({
         name: card.name,
         location: card.location,
@@ -91,9 +110,10 @@ function ResultPage(props) {
       pieChart.labels = [];
       const votes = [];
       for (let i = 0; i < cardList.length; i++) {
-        if (cardList[i].name && i < 6) {
+        if (cardList[i].name) {
           pieChart.labels.push(cardList[i].name);
           votes.push(cardList[i].numberOfVotes);
+          pieColours.push(randomColour());
         } else {
           break;
         }
@@ -104,22 +124,8 @@ function ResultPage(props) {
           label: '# of Votes',
           data: votes,
           defaultFontColor: '#fff',
-          borderColor: [
-            'rgba(255, 99, 132, 0.2)',
-            'rgba(54, 162, 235, 0.2)',
-            'rgba(255, 206, 86, 0.2)',
-            'rgba(75, 192, 192, 0.2)',
-            'rgba(153, 102, 255, 0.2)',
-            'rgba(255, 159, 64, 0.2)',
-          ],
-          backgroundColor: [
-            'rgba(255, 99, 132, 1)',
-            'rgba(54, 162, 235, 1)',
-            'rgba(255, 206, 86, 1)',
-            'rgba(75, 192, 192, 1)',
-            'rgba(153, 102, 255, 1)',
-            'rgba(255, 159, 64, 1)',
-          ],
+          borderColor: pieColours,
+          backgroundColor: pieColours,
           borderWidth: 1,
         },
       ];

--- a/frontend/src/components/7.Result/ResultPage.js
+++ b/frontend/src/components/7.Result/ResultPage.js
@@ -90,13 +90,7 @@ function ResultPage(props) {
   useEffect(() => {
     if (cardList && cardList.length > 0) {
       setHasResult(true);
-      // Get all restaurants that have the most keens
-      const topRestaurants = cardList.filter(
-        (card) => card.numberOfVotes === cardList[0].numberOfVotes
-      );
-      // Select a top restaurant randomly
-      const card =
-        topRestaurants[Math.floor(Math.random() * topRestaurants.length)];
+      const card = cardList[0];
       setData({
         name: card.name,
         location: card.location,

--- a/frontend/src/components/7.Result/ResultPage.js
+++ b/frontend/src/components/7.Result/ResultPage.js
@@ -56,14 +56,19 @@ function ResultPage(props) {
   const pieColours = [];
 
   /**
-   * This function generates a random RGB value
-   * @return {string} A string that represents an RGB colour value
+   * This function generates a random HSL value
+   * @return {string} A string that represents a HSL colour value
    */
   const randomColour = () => {
-    const r = Math.floor(Math.random() * 255);
-    const g = Math.floor(Math.random() * 255);
-    const b = Math.floor(Math.random() * 255);
-    return 'rgb(' + r + ',' + g + ',' + b + ')';
+    return (
+      'hsl(' +
+      360 * Math.random() +
+      ',' +
+      (60 + 30 * Math.random()) +
+      '%,' +
+      80 +
+      '%)'
+    );
   };
 
   useEffect(() => {
@@ -118,8 +123,9 @@ function ResultPage(props) {
           label: '# of Votes',
           data: votes,
           defaultFontColor: '#fff',
-          borderColor: pieColours,
+          borderColor: '#000',
           backgroundColor: pieColours,
+          hoverBackgroundColor: pieColours,
           borderWidth: 1,
         },
       ];


### PR DESCRIPTION
Fixes part of #328 

All restaurants within the session are now shown in the Results modal Pie Chart. Previously, there was a hard coded limit of 6 restaurants.
To accommodate this change, I've also removed the hardcoded Pie Chart colour values and instead, a random colour generator is used. 

Before:
![image](https://user-images.githubusercontent.com/7234148/115258342-01ed8e00-a185-11eb-90e5-7ead5129676c.png)

After:
![image](https://user-images.githubusercontent.com/7234148/115261661-e932a780-a187-11eb-9c5a-109322ee0d39.png)

