### PR TITLE
[FEAT] Implement Random Top Choice functionality

### DIFF
--- a/backend/src/mongo/models/Session.js
+++ b/backend/src/mongo/models/Session.js
@@ -1,8 +1,7 @@
 import mongoose from 'mongoose';
 
-import {preferenceSchema} from './Preference';
-import {restaurantSchema} from './Restaurant';
-
+import { preferenceSchema } from './Preference';
+import { restaurantSchema } from './Restaurant';
 
 const sessionSchema = mongoose.Schema({
   truncCode: {
@@ -21,9 +20,12 @@ const sessionSchema = mongoose.Schema({
     type: [restaurantSchema],
     required: true,
   },
+  topChoice: {
+    type: restaurantSchema,
+    required: false,
+  },
 
-  createdAt: {type: Date, default: Date.now},
-
+  createdAt: { type: Date, default: Date.now },
 });
 
 export default mongoose.model('Session', sessionSchema);

--- a/frontend/src/components/7.Result/ResultPage.js
+++ b/frontend/src/components/7.Result/ResultPage.js
@@ -70,11 +70,16 @@ function ResultPage(props) {
       .then((res) => {
         setHasResult(false);
         // Sort Restaurants by number of Keen votes
-        setCardList(
-          res.data.results.sort(function (a, b) {
-            return b.numberOfVotes - a.numberOfVotes;
-          })
-        );
+        setCardList(res.data.results);
+        const card = res.data.topChoice;
+        setData({
+          name: card.name,
+          location: card.location,
+          price: card.price,
+          rating: card.rating,
+          images: card.images,
+          coords: card.coords,
+        });
       })
       .catch(function (error) {
         console.log(error);
@@ -87,15 +92,6 @@ function ResultPage(props) {
   useEffect(() => {
     if (cardList && cardList.length > 0) {
       setHasResult(true);
-      const card = cardList[0];
-      setData({
-        name: card.name,
-        location: card.location,
-        price: card.price,
-        rating: card.rating,
-        images: card.images,
-        coords: card.coords,
-      });
 
       const pieChart = {};
       pieChart.labels = [];


### PR DESCRIPTION
Fixes the 2nd half of #328.

When the first user enters the Results Page, the backend will sort Restaurants based on number of votes, and get the top Choice by randomly selecting among the restaurants that have the highest number of votes. Once this has been completed, the data is persisted to the database.

Additional accesses to the Results Page (other players at game over, revisiting the session after game over), will skip this process and instead will use the data that has been calculated already.

This means the Top Choice is now persisted to the session and all users in the session will see the same Top Choice.

I've also updated the Mongo 'Session' Schema as necessary to accommodate the Top Choice field in the session.

This is hard to illustrate through screenshots unfortunately, so will require testing. However, I've tested it locally multiple times and it seems to work, even with one restaurant. 
